### PR TITLE
Refactoring for csuite integration

### DIFF
--- a/cagecleaner/file_utils.py
+++ b/cagecleaner/file_utils.py
@@ -10,7 +10,7 @@ from Bio import SeqIO
 from subprocess import CalledProcessError
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 def remove_suffixes(string: str | Path) -> str:
@@ -160,7 +160,7 @@ def _convert_one_genbank_to_fasta(input_output_paths: tuple[Path]) -> None:
                 # use -q for quiet mode, text=True because output is not in byte form.
                 subprocess.run(['any2fasta', '-q', '-g', str(in_file)], stdout=handle, check=True, text=True)
             except CalledProcessError as err:
-                LOG.err(err)
+                LOG.error(err)
                 raise err
             
     except FileNotFoundError as err:

--- a/cagecleaner/generate_session.py
+++ b/cagecleaner/generate_session.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from cblaster.classes import Session
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
+
 logging.basicConfig(
     level = logging.ERROR,
     format = "[%(asctime)s] %(levelname)s [%(filename)s: %(funcName)s] - %(message)s",

--- a/cagecleaner/genome_run.py
+++ b/cagecleaner/genome_run.py
@@ -7,7 +7,7 @@ from cagecleaner.utils import run_command
 import logging
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class GenomeRun(Run):
@@ -26,22 +26,16 @@ class GenomeRun(Run):
         """
         Initialise a GenomeRun instance.
         
-        Runs the base class init and checks for a valid ANI threshold.
+        Runs the base class init.
         
         Args:
             args (argparse.Namespace): Parsed command-line arguments
-            
-        Raises:
-            ValueError: If identity threshold is not between 82 and 100, the threshold region support by skani.
             
         Returns:
             None
         """
         
         super().__init__(args)
-        
-        if not(args.identity <= 100 and args.identity >= 82):
-            raise ValueError("Identity threshold should be between 82 % and 100 % in case of full-genome-based dereplication (see skani documentation).")
         
         return None
     

--- a/cagecleaner/local_genome_run.py
+++ b/cagecleaner/local_genome_run.py
@@ -6,11 +6,12 @@ from cagecleaner.genome_run import GenomeRun
 from cagecleaner.file_utils import remove_suffixes
 
 import logging
+import shutil
 import pandas as pd
 from pathlib import Path
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class LocalGenomeRun(LocalRun, GenomeRun):
@@ -27,7 +28,7 @@ class LocalGenomeRun(LocalRun, GenomeRun):
         GenomeRun: Intermediary class providing genome dereplication utilities.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a LocalGenomeRun instance.
         
@@ -35,15 +36,16 @@ class LocalGenomeRun(LocalRun, GenomeRun):
         and logging infrastructure.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
         
         Returns:
             None
         """
         
-        super().__init__(args)
+        super().__init__(parsed_args)
         
         return None
+    
     
     def join_dereplication_with_binary(self) -> None:
         """
@@ -157,7 +159,7 @@ class LocalGenomeRun(LocalRun, GenomeRun):
         
         # Remove the temporary directory:
         LOG.info("Cleaning up temporary directory.")
-        self.TEMP_DIR_CONTEXT.cleanup()
+        shutil.rmtree(self.TEMP_DIR)
         
         return None
     

--- a/cagecleaner/local_region_run.py
+++ b/cagecleaner/local_region_run.py
@@ -6,13 +6,14 @@ from cagecleaner.region_run import RegionRun
 from cagecleaner.file_utils import _extract_one_region
 
 import logging
+import shutil
 import pandas as pd
 import numpy as np
 from pathlib import Path
 from tqdm.contrib.concurrent import thread_map
 from tqdm.contrib.logging import logging_redirect_tqdm
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class LocalRegionRun(LocalRun, RegionRun):
@@ -31,7 +32,7 @@ class LocalRegionRun(LocalRun, RegionRun):
         LocalRun: Intermediary class providing local file handling utilities.
         RegionRun: Intermediary class providing region dereplication utilities.
     """
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a LocalRegionRun instance.
         
@@ -39,13 +40,13 @@ class LocalRegionRun(LocalRun, RegionRun):
         and logging infrastructure.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
         
         Returns:
             None
         """
         
-        super().__init__(args)
+        super().__init__(parsed_args)
         
         return None
     
@@ -204,7 +205,7 @@ class LocalRegionRun(LocalRun, RegionRun):
         
         # Remove the temporary directory:
         LOG.info("Cleaning up temporary directory.")
-        self.TEMP_DIR_CONTEXT.cleanup()
+        shutil.rmtree(self.TEMP_DIR)
     
         return None
     

--- a/cagecleaner/local_run.py
+++ b/cagecleaner/local_run.py
@@ -7,7 +7,7 @@ from cagecleaner.file_utils import is_fasta, is_genbank, remove_suffixes, conver
 import logging
 from abc import abstractmethod
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class LocalRun(Run):
@@ -22,43 +22,31 @@ class LocalRun(Run):
          LocalGenomeRun: Whole-genome dereplication for hits in local sequences.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a LocalRun instance.
         
-        Runs the base class init and checks for valid keep flags.
-        Checks whether genome folder only contains valid genome sequence files.
-        Excludes scaffolds from the analysis as specified by the user.
+        Runs the base class init and excludes scaffolds from the analysis as specified by the user.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
             
         Returns:
             None
             
         Raises:
-            ValueError: If the download flag has been enabled in local mode.
-            ValueError: If the user-supplied local genome directory does not contain any fasta or genbank file.
-            ValueError: If there are no hits left in the binary table after excluding scaffolds or organisms.
+            RuntimeError: If there are no hits left in the binary table after excluding scaffolds or organisms.
         """
                 
         # Call the parent class initiator
-        super().__init__(args)
+        super().__init__(parsed_args)
         
-        # Can't keep downloads in local mode. Also make sure keep_intermediate doesn't fail.
-        if self.keep_downloads == True:
-            raise ValueError("Can't keep downloads in local mode.")
+        # Automatically toggle off keeping both downloads and dereplication in local mode,
+        # since there won't be downloaded anything.
         if self.keep_intermediate:
             self.keep_intermediate = False
+            self.keep_downloads = False
             self.keep_dereplication = True
-        
-        # Make sure there is no exotic stuff in the provided genome folder
-        try:
-            next(filter(lambda x: is_fasta(x) or is_genbank(x), self.USER_GENOME_DIR.iterdir()))
-        except StopIteration:
-            msg = "The user-supplied genome directory does not contain any fasta or genbank file!"
-            LOG.critical(msg)
-            raise ValueError(msg)
         
         # Remove organisms that the user wants to be excluded:
         if self.excluded_organisms != {''}:
@@ -68,7 +56,7 @@ class LocalRun(Run):
             if self.binary_df.empty:
                 msg = "No hits left after excluding organisms!"
                 LOG.error(msg)
-                raise ValueError(msg)
+                raise RuntimeError(msg)
 
         # Remove scaffold IDs specified by the user:
         if self.excluded_scaffolds != {''}:
@@ -84,7 +72,7 @@ class LocalRun(Run):
             if self.binary_df.empty:
                 msg = "No hits left after excluding scaffolds!"
                 LOG.error(msg)
-                raise ValueError(msg)
+                raise RuntimeError(msg)
             
         return None
     

--- a/cagecleaner/main.py
+++ b/cagecleaner/main.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from cagecleaner.local_genome_run import LocalGenomeRun
-from cagecleaner.local_region_run import LocalRegionRun
-from cagecleaner.remote_genome_run import RemoteGenomeRun
-from cagecleaner.remote_region_run import RemoteRegionRun
-
 import argparse
 import tempfile
 import sys
@@ -15,20 +10,29 @@ from pathlib import Path
 from importlib.metadata import version
 from cblaster.classes import Session
 
+from cagecleaner.local_genome_run import LocalGenomeRun
+from cagecleaner.local_region_run import LocalRegionRun
+from cagecleaner.remote_genome_run import RemoteGenomeRun
+from cagecleaner.remote_region_run import RemoteRegionRun
+from cagecleaner.validators import parse_and_validate_arguments
+
 __version__ = version("cagecleaner")
 
 warnings.filterwarnings(action = 'ignore', module = 'cblaster')
-LOG = logging.getLogger()
 
-def parse_arguments() -> argparse.Namespace:
+
+LOG = logging.getLogger(__name__)
+
+
+def create_parser() -> argparse.Namespace:
     """
-    This function parses the arguments given through the command line.
+    This function creates a parser object that will collect the arguments given through the command line.
     
     Args:
         None
     
     Returns:
-        A Namespace object holding the parsed arguments
+        parser (argparse.ArgumentParser): An ArgumentParser object holding the CLI ready to collect the arguments when called
         
     Note:
         Also configures the logger.
@@ -64,10 +68,10 @@ def parse_arguments() -> argparse.Namespace:
     
     args_io = parser.add_argument_group('File inputs and outputs')
     args_io.add_argument('-s', '--session', dest = "session", type = Path, required = True, help = "Path to cblaster session (either obtained from a search run or from cagecleaner-generate-session).")
-    args_io.add_argument('-g', '--genomes', dest = "genome_dir", type = Path, default = '.', 
+    args_io.add_argument('-g', '--genomes', dest = "genome_dir", type = Path, default = Path('.'), 
                          help = "[Only relevant for local searches] Path to local genome folder containing genome files. Accepted formats are FASTA and Genbank [.fasta; .fna; .fa; .gbff; .gbk; .gb]. Files can be gzipped. (default: current working directory)")
-    args_io.add_argument('-o', '--output', dest = "output_dir", type = Path, default = '.', help = "Output directory (default: current working directory).")
-    args_io.add_argument('-t', '--temp', dest = "temp_dir", type = Path, default = tempfile.gettempdir(), help = "Path to store temporary files (default: your OS's default temporary directory).")
+    args_io.add_argument('-o', '--output', dest = "output", type = Path, default = Path('.'), help = "Output directory (default: current working directory).")
+    args_io.add_argument('-t', '--temp', dest = "temp", type = Path, default = Path(tempfile.gettempdir()), help = "Path to store temporary files (default: your OS's default temporary directory).")
     args_io.add_argument('--keep_downloads', dest = "keep_downloads", default = False, action = "store_true", help = "Keep downloaded genomes.")
     args_io.add_argument('--keep_dereplication', dest = "keep_dereplication", default = False, action = "store_true", help = "Keep dereplication intermediary output.")
     args_io.add_argument('--keep_intermediate', dest = "keep_intermediate", default = False, action = "store_true", help = "Keep all intermediate data. This overrules other keep flags.")
@@ -101,10 +105,23 @@ def parse_arguments() -> argparse.Namespace:
     args_recovery.add_argument('--min_z_score', dest = 'zscore_outlier_threshold', default = 2.0, type = float, help = "z-score threshold to consider hits outliers (default: 2.0)")
     args_recovery.add_argument('--min_score_diff', dest = 'minimal_score_difference', default = 0.1, type = float, help = "minimum score difference between hits to be considered different. Discards outlier hits with a score difference below this threshold. (default: 0.1)")
 
-    # Parse arguments
-    args = parser.parse_args()
+    return parser
+
+
+def setup_logging(verbosity: int) -> None:
+    """
+    Set up the root logger if it has not been set up yet.
     
-    # Set up logger
+    Args:
+        verbosity (int): Verbosity level (choices: 0,1,2,3,4).
+        
+    Returns:
+        None
+    """
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return None
+    
     log_levels = {0: logging.CRITICAL,
                   1: logging.ERROR,
                   2: logging.WARNING,
@@ -112,49 +129,54 @@ def parse_arguments() -> argparse.Namespace:
                   4: logging.DEBUG
                   }
     logging.basicConfig(
-        level = log_levels[args.verbosity],
+        level = log_levels[verbosity],
         format = "[%(asctime)s] %(levelname)s [%(filename)s: %(funcName)s] - %(message)s",
         datefmt="%H:%M:%S",
         handlers = [logging.StreamHandler(sys.stdout)]
         )
     
-    # Validate required arguments
-    if args is None:
-        msg = "No arguments were parsed. ArgParse object is None."
-        LOG.error(msg)
-        raise argparse.ArgumentError(msg)
+    return None
     
+
+def main():
+    # First we parse the arguments:
+    parser = create_parser()
+    args = parser.parse_args()
+    
+    # Check whether the session file exist and the verbosity value is valid. We'll definitely need these
+    # to find out which workflow we need to initiate, which validation checks to run and to set up the logger.
     if not args.session.exists():
         msg = f"Session not found at {args.session}"
         LOG.error(msg)
-        raise IOError(msg)
+        raise FileNotFoundError(msg)
+    if args.verbosity not in [0,1,2,3,4]:
+        msg = f'Invalid verbosity level: {args.verbosity}. Valid levels are 0, 1, 2, 3, and 4.'
+        LOG.error(msg)
+        raise ValueError(msg)
         
-    return args
-
-
-def main():
+    # Set up logger
+    setup_logging(args.verbosity)
     
-    # First we parse the arguments:
-    args = parse_arguments()
+    # Validate arguments
+    parsed_args = parse_and_validate_arguments(args)
     
-    # Initiate the approriate CAGEcleaner Run object:
-    LOG.info("--- Loading session file. ---")
+    # Initiate the approriate CAGEcleaner Run object
     source = Session.from_file(args.session).params['mode']
-    method = args.method
+    method = parsed_args['method']
     mode = (source, method)
     match mode:
         case ('remote', 'genomes'):
             LOG.info('Entering remote genome mode')
-            my_run = RemoteGenomeRun(args)
+            my_run = RemoteGenomeRun(parsed_args)
         case ('remote', 'regions'):
             LOG.info('Entering remote region mode')
-            my_run = RemoteRegionRun(args)
+            my_run = RemoteRegionRun(parsed_args)
         case ('local', 'genomes') | ('hmm', 'genomes'):
             LOG.info('Entering local genome mode')
-            my_run = LocalGenomeRun(args)
+            my_run = LocalGenomeRun(parsed_args)
         case ('local', 'regions') | ('hmm', 'regions'):
             LOG.info('Entering local region mode')
-            my_run = LocalRegionRun(args)
+            my_run = LocalRegionRun(parsed_args)
         case _:
             LOG.critical(f'Invalid mode detected: {mode}. Exiting.')
             raise argparse.ArgumentError(f'Invalid search mode detected: {mode}')

--- a/cagecleaner/region_run.py
+++ b/cagecleaner/region_run.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class RegionRun(Run):
@@ -23,14 +23,14 @@ class RegionRun(Run):
          RemoteRegionRun: Region-based dereplication for hits in remote sequences.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a RegionRun instance.
         
         Runs the base class init and checks for a valid identity threshold and sequence margin.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
             
         Raises:
             ValueError: If identity threshold is not a percentage value, or if sequence margin is not a positive number.
@@ -39,16 +39,7 @@ class RegionRun(Run):
             None
         """
         
-        super().__init__(args)
-        
-        try:
-            if not(args.identity <= 100 and args.identity >= 0):
-                raise ValueError("Identity threshold should be between 0 and 100 in case of region-based dereplication.")
-            if not(args.margin >= 0):
-                raise ValueError("Region margin cannot be negative when dereplicating regions.")
-        except ValueError as err:
-            LOG.error(f'{err}')
-            raise err
+        super().__init__(parsed_args)
         
         self.DEREP_IN_DIR: Path = self.TEMP_DIR / 'regions' # Path where the genomic regions will be saved temporarily for region-based dereplication
         self.DEREP_IN_DIR.mkdir(parents = True)

--- a/cagecleaner/remote_genome_run.py
+++ b/cagecleaner/remote_genome_run.py
@@ -19,7 +19,7 @@ from Bio import SeqIO
 from tqdm import tqdm
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class RemoteGenomeRun(RemoteRun, GenomeRun):
@@ -38,7 +38,7 @@ class RemoteGenomeRun(RemoteRun, GenomeRun):
         GenomeRun: Intermediary class providing genome dereplication utilities.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a RemoteGenomeRun instance.
         
@@ -46,17 +46,10 @@ class RemoteGenomeRun(RemoteRun, GenomeRun):
         for tracking assembly accessions and scaffold-to-assembly mappings.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
-        
-        Raises:
-            ValueError: If download_batch is not greater than 0.
+            parsed_args (dict): Parsed and validated command-line arguments
         """
         
-        super().__init__(args)
-        
-        # Defensive check:
-        if not(args.download_batch > 0): 
-            raise ValueError("Download batch should be larger than 0.")
+        super().__init__(parsed_args)
         
         # Variable to store assembly accessions:
         self.assembly_accessions: list = []
@@ -440,7 +433,7 @@ class RemoteGenomeRun(RemoteRun, GenomeRun):
         
         # Remove the temporary directory:
         LOG.info("Cleaning up temporary directory.")
-        self.TEMP_DIR_CONTEXT.cleanup()
+        shutil.rmtree(self.TEMP_DIR)
         
         return None
     

--- a/cagecleaner/remote_region_run.py
+++ b/cagecleaner/remote_region_run.py
@@ -7,12 +7,13 @@ from cagecleaner.communication import fetch_contig_lengths, download_regions
 
 import logging
 import warnings
+import shutil
 import pandas as pd
 import numpy as np
 from pathlib import Path
 
 warnings.filterwarnings(action = "ignore", module = "Bio")
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class RemoteRegionRun(RemoteRun, RegionRun):
@@ -37,7 +38,7 @@ class RemoteRegionRun(RemoteRun, RegionRun):
         RegionRun: Intermediary class providing region dereplication utilities
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a RemoteRegionRun instance.
         
@@ -45,13 +46,13 @@ class RemoteRegionRun(RemoteRun, RegionRun):
         and logging infrastructure.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
         
         Returns:
             None
         """
         
-        super().__init__(args)
+        super().__init__(parsed_args)
         
         return None
     
@@ -296,7 +297,7 @@ class RemoteRegionRun(RemoteRun, RegionRun):
         
         # Remove the temporary directory:
         LOG.info("Cleaning up temporary directory.")
-        self.TEMP_DIR_CONTEXT.cleanup()
+        shutil.rmtree(self.TEMP_DIR)
         
         return None
     

--- a/cagecleaner/remote_run.py
+++ b/cagecleaner/remote_run.py
@@ -7,7 +7,7 @@ import logging
 from abc import abstractmethod
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class RemoteRun(Run):
@@ -22,7 +22,7 @@ class RemoteRun(Run):
          RemoteGenomeRun: Whole-genome dereplication for hits in remote sequences.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a RemoteRun instance.
         
@@ -30,16 +30,16 @@ class RemoteRun(Run):
         Excludes scaffolds from the analysis as specified by the user.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
             
         Returns:
             None
             
         Raises:
-            ValueError: If there are no hits left in the binary table after excluding scaffolds or organisms.
+            RuntimeError: If there are no hits left in the binary table after excluding scaffolds or organisms.
         """
         # Call the parent constructor:
-        super().__init__(args)
+        super().__init__(parsed_args)
         
         # Remove Organisms specified by the user:
         if self.excluded_organisms != {''}:
@@ -52,7 +52,7 @@ class RemoteRun(Run):
             if self.binary_df.empty:
                 msg = "No hits left after excluding organisms!"
                 LOG.error(msg)
-                raise ValueError(msg)
+                raise RuntimeError(msg)
         
         # Remove scaffolds that the user wants excluded:
         if self.excluded_scaffolds != {''}:
@@ -62,13 +62,14 @@ class RemoteRun(Run):
             if self.binary_df.empty:
                 msg = "No hits left after excluding scaffolds!"
                 LOG.error(msg)
-                raise ValueError(msg)
+                raise RuntimeError(msg)
         
         # Replace colons in the bypass assemblies as wel:
         if self.bypass_organisms != {''}:
             self.bypass_organisms = {org.replace(':', ' ') for org in self.bypass_organisms}
             
         return None
+    
     
     @abstractmethod
     def join_dereplication_with_binary(self):

--- a/cagecleaner/run.py
+++ b/cagecleaner/run.py
@@ -8,7 +8,6 @@ import pandas as pd
 import os
 import shutil
 import logging
-from tempfile import TemporaryDirectory
 from abc import ABC, abstractmethod
 from pathlib import Path
 from copy import deepcopy
@@ -18,7 +17,7 @@ from cblaster.classes import Session
 from cblaster.extract_clusters import get_sorted_cluster_hierarchies
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class Run(ABC):
@@ -50,7 +49,7 @@ class Run(ABC):
         RemoteRegionRun: Region-based dereplication for hits in remote sequences.
     """
     
-    def __init__(self, args):
+    def __init__(self, parsed_args):
         """
         Initialise a Run instance.
         
@@ -59,7 +58,7 @@ class Run(ABC):
         Generates layout groups for all hits and corrects them for strand location if necessary.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
+            parsed_args (dict): Parsed and validated command-line arguments
                 
         Raises:
             IOError: If provided genome directory does not exist
@@ -72,85 +71,57 @@ class Run(ABC):
         
         super().__init__()
         
-        ## Some defensive checks: ##
-        try:
-            if not (args.genome_dir.exists()):
-                raise IOError(f"Provided genome directory does not exits: {args.genome_dir}.")
-            if not (args.coverage >= 0 and args.coverage <= 100):
-                raise ValueError("Coverage threshold should be a number between 0 and 100.")
-            if not(args.zscore_outlier_threshold > 0):
-                raise ValueError("Z-score threshold for recovery should be greater than zero.")
-            if not(args.minimal_score_difference >= 0):
-                raise ValueError("Minimal score difference for recovery cannot be smaller than zero.")
-            if not(args.cores > 0):
-                raise ValueError("Amount of CPU cores to use should be greater than zero.")
-        except (IOError, ValueError) as err:
-            LOG.error(f'{err}')
-            raise err
-        
         ## Passing on the CLI arguments
         # Parse the general arguments:
-        self.cores: int = args.cores
-        self.verbosity: int = args.verbosity
-        self.no_progress: bool = args.no_progress
+        self.cores: int = parsed_args['cores']
+        self.verbosity: int = parsed_args['verbosity']
+        self.no_progress: bool = parsed_args['no_progress']
         
         # Parse IO arguments:
-        self.keep_dereplication: bool = args.keep_dereplication
-        self.keep_downloads: bool = args.keep_downloads
-        self.keep_intermediate: bool = args.keep_intermediate
+        self.keep_dereplication: bool = parsed_args['keep_dereplication']
+        self.keep_downloads: bool = parsed_args['keep_downloads']
+        self.keep_intermediate: bool = parsed_args['keep_intermediate']
         
         # Define paths and check output folder
-        self.OUT_DIR: Path = args.output_dir.resolve()  # Output directory
-        Path(args.temp_dir).resolve().mkdir(parents = True, exist_ok = True)
-        self.TEMP_DIR_CONTEXT: TemporaryDirectory = TemporaryDirectory(dir = args.temp_dir, delete = False)  # Temporary directory (within the given temporary directory)
-        self.TEMP_DIR: Path = Path(self.TEMP_DIR_CONTEXT.name)
-        self.USER_GENOME_DIR: Path = args.genome_dir.resolve()  # Genome directory provided by the user
+        self.OUT_DIR: Path = parsed_args['output'].resolve()  # Output directory
+        self.TEMP_DIR: Path = parsed_args['temp'].resolve()
+        self.USER_GENOME_DIR: Path = parsed_args['genome_dir'].resolve()  # Genome directory provided by the user
         self.DEREP_OUT_DIR: Path = self.TEMP_DIR / 'derep_out'
         self.DEREP_IN_DIR: Path | None = None # Input directory for the dereplication.
         
-        # Output directory should not exist yet, unless flagged.
-        try:
-            self.OUT_DIR.mkdir(parents = True)
-        except FileExistsError as err:
-            if args.force:
-                LOG.warning('Output folder already exists, but it will be overwritten.')
-            else:
-                LOG.error('Output folder already exists! Rerun with -f to overwrite it.')
-                raise err
-            
         # Parse bypass and excluded scaffolds/assemblies:
-        self.bypass_organisms: set = {i.strip() for i in args.bypass_organisms.split(',')}  # Converts comma-separated sequence to a set.
-        self.bypass_scaffolds: set = {i.strip() for i in args.bypass_scaffolds.split(',')}
-        self.excluded_organisms: set = {i.strip() for i in args.excluded_organisms.split(',')}
-        self.excluded_scaffolds: set = {i.strip() for i in args.excluded_scaffolds.split(',')}
+        self.bypass_organisms: set = {i.strip() for i in parsed_args['bypass_organisms'].split(',')}  # Converts comma-separated sequence to a set.
+        self.bypass_scaffolds: set = {i.strip() for i in parsed_args['bypass_scaffolds'].split(',')}
+        self.excluded_organisms: set = {i.strip() for i in parsed_args['excluded_organisms'].split(',')}
+        self.excluded_scaffolds: set = {i.strip() for i in parsed_args['excluded_scaffolds'].split(',')}
 
         # Download arguments:
-        self.download_workers: int = args.download_workers
-        self.download_batch: int = args.download_batch
+        self.download_workers: int = parsed_args['download_workers']
+        self.download_batch: int = parsed_args['download_batch']
         
         # Dereplication arguments:
-        self.strict_regions: bool = args.strict_regions
-        self.identity: float = args.identity
-        self.coverage: float = args.coverage
-        self.low_mem: bool = args.low_mem
-        self.margin: int = args.margin
+        self.strict_regions: bool = parsed_args['strict_regions']
+        self.identity: float = parsed_args['identity']
+        self.coverage: float = parsed_args['coverage']
+        self.low_mem: bool = parsed_args['low_mem']
+        self.margin: int = parsed_args['margin']
         
         # Hit recovery arguments:
-        self.no_recovery_by_content: bool = args.no_recovery_by_content
-        self.no_recovery_by_score: bool = args.no_recovery_by_score
-        self.zscore_outlier_threshold: float = args.zscore_outlier_threshold
-        self.minimal_score_difference: float = args.minimal_score_difference
+        self.no_recovery_by_content: bool = parsed_args['no_recovery_by_content']
+        self.no_recovery_by_score: bool = parsed_args['no_recovery_by_score']
+        self.zscore_outlier_threshold: float = parsed_args['zscore_outlier_threshold']
+        self.minimal_score_difference: float = parsed_args['minimal_score_difference']
         
         # This variable will store the filtered session file, the end result.
         self.filtered_session: Session | None = None
         
         ## Initialise the binary table
-        self._initialise_binary(args)
+        self.initialise_binary(parsed_args['session'])
         
         return None
     
     
-    def _initialise_binary(self, args):
+    def initialise_binary(self, session: Path):
         """
         Initialise the binary table from the provided session file (either obtained from a search run,
         or from cagecleaner-generate-session).
@@ -161,20 +132,17 @@ class Run(ABC):
         Generates cluster layout groups from this and corrects them for strand location.
         
         Args:
-            args (argparse.Namespace): Parsed command-line arguments
-            
-        Note:
-            Exits when no valid input files have been found.
+            session (pathlib.Path): Path of the session file from which the initial binary table will be created.
             
         Raises:
-            ValueError: If the initial binary is empty, and thus the session is empty.
+            ValueError: If the initial binary is empty, and thus the supplied session was empty.
         
         Returns:
             None
         """
         ## Get a Session object from the inputs
         LOG.info('Parsing cblaster session.')
-        self.session: Session = Session.from_file(args.session.resolve())
+        self.session: Session = Session.from_file(session.resolve())
         
         ## Now get the information we want from the session
         # First generate and parse the binary table

--- a/cagecleaner/utils.py
+++ b/cagecleaner/utils.py
@@ -13,7 +13,7 @@ from cblaster.classes import Session
 from pathlib import Path
 
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 def correct_layouts(binary_df: pd.DataFrame) -> pd.DataFrame:

--- a/cagecleaner/validators.py
+++ b/cagecleaner/validators.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+import argparse
+import tempfile
+from pathlib import Path
+from cblaster.classes import Session
+
+from cagecleaner.file_utils import is_fasta, is_genbank
+
+
+LOG = logging.getLogger(__name__)
+
+
+def parse_and_validate_arguments(args: argparse.Namespace, bypass_source: None | str = None) -> dict:
+    """
+    This function validates the parsed arguments given through the command line.
+    
+    Args:
+        parser (argparse.NameSpace): A NameSpace object with parsed CLI arguments
+        bypass_source (None | str): Override CCL's assessment of the sequence source. Defaults to None,
+            which sticks to CCL's assessment. Necessary for compatibility with csuite's validation checkers.
+    
+    Returns:
+        parsed_args (dict): A dictionary holding the parsed and validated argument values.
+        
+    Raises:
+        ValueError: if an invalid argument value was given.
+    """
+    # Determine sequence source
+    match bypass_source:
+        case None:
+            LOG.info("--- Loading session file. ---")
+            source = Session.from_file(args.session).params['mode']
+        case 'local' | 'remote':
+            source = bypass_source
+        case _:
+            raise ValueError('Overrided source is not valid! Possible choices: "local", "remote".')
+    
+    # Run appropriate validation checks
+    method = args.method
+    mode = (source, method)
+    match mode:
+        case ('remote', 'genomes'):
+            validate_remote_genome_run_args(args)
+        case ('remote', 'regions'):
+            validate_remote_region_run_args(args)
+        case ('local', 'genomes') | ('hmm', 'genomes'):
+            validate_local_genome_run_args(args)
+        case ('local', 'regions') | ('hmm', 'regions'):
+            validate_local_region_run_args(args)
+        case _:
+            LOG.critical(f'Invalid mode detected: {mode}. Exiting.')
+            raise argparse.ArgumentError(f'Invalid search mode detected: {mode}')
+    
+    # Parse arguments
+    parsed_args = vars(args)
+    
+    return parsed_args
+
+
+def validate_run_args(args: argparse.Namespace):
+    """
+    Validates the arguments processed at the level of the base Run class.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+        FileExistsError: If the output directory already exists and the force flag was not on.
+    """
+    try:
+        if not(args.genome_dir.exists()):
+            raise ValueError(f"Provided genome directory does not exits: {args.genome_dir}.")
+        if not (args.coverage >= 0 and args.coverage <= 100):
+            raise ValueError("Coverage threshold should be a number between 0 and 100.")
+        if not(args.zscore_outlier_threshold > 0):
+            raise ValueError("Z-score threshold for recovery should be greater than zero.")
+        if not(args.minimal_score_difference >= 0):
+            raise ValueError("Minimal score difference for recovery cannot be smaller than zero.")
+        if not(args.cores > 0):
+            raise ValueError("Amount of CPU cores to use should be greater than zero.")
+    except ValueError as err:
+        LOG.error(f'{err}')
+        raise err
+        
+    # Output directory should not exist yet, unless flagged.
+    try:
+        args.output.mkdir(parents = True)
+    except FileExistsError as err:
+        if args.force:
+            LOG.warning('Output folder already exists, but it will be overwritten.')
+        else:
+            LOG.error('Output folder already exists! Rerun with -f to overwrite it.')
+            raise err
+            
+    # Temporary directory should not exist yet if not default, unless flagged.
+    if args.temp != Path(tempfile.gettempdir()):
+        try:
+            args.temp.mkdir(parents = True)
+        except FileExistsError as err:
+            if args.force:
+                LOG.warning('Temporary folder already exists, but it will be overwritten.')
+            else:
+                msg = 'Temporary folder already exists! Rerun with -f to overwrite it.'
+                LOG.error(msg)
+                raise err
+    args.temp = Path(tempfile.mkdtemp(dir = args.temp))
+            
+    return None
+
+
+def validate_local_run_args(args: argparse.Namespace, skip_base: bool = False):
+    """
+    Validates the arguments processed at the level of the intermediary Local class.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        skip_base (bool): Skip validating the base class argument values. This eliminates redundant checks when
+            validating the arguments of the parent classes in this multiple inheritance class system.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    if not skip_base:
+        validate_run_args(args)
+    
+    if args.keep_downloads == True:
+        raise ValueError("Can't keep downloads in local mode.")
+        
+    # Make sure there is no exotic stuff in the provided genome folder
+    try:
+        next(filter(lambda x: is_fasta(x) or is_genbank(x), args.genome_dir.iterdir()))
+    except StopIteration:
+        print(args.genome_dir.resolve())
+        msg = "The user-supplied genome directory does not contain any fasta or genbank file!"
+        LOG.critical(msg)
+        raise ValueError(msg)
+        
+    return None
+
+
+def validate_remote_run_args(args: argparse.Namespace, skip_base: bool = False):
+    """
+    Validates the arguments processed at the level of the intermediary Remote class.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        skip_base (bool): Skip validating the base class argument values. This eliminates redundant checks when
+            validating the arguments of the parent classes in this multiple inheritance class system.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    if not skip_base:
+        validate_run_args(args)
+    
+    return None
+
+
+def validate_genome_run_args(args: argparse.Namespace, skip_base: bool = False):
+    """
+    Validates the arguments processed at the level of the intermediary Genome class.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        skip_base (bool): Skip validating the base class argument values. This eliminates redundant checks when
+            validating the arguments of the parent classes in this multiple inheritance class system.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid identity threshold value was passed
+    """
+    
+    if not skip_base:
+        validate_run_args(args)
+    
+    if not(args.identity <= 100 and args.identity >= 82):
+        raise ValueError("Identity threshold should be between 82 % and 100 % in case of full-genome-based dereplication (see skani documentation).")
+        
+    return None
+
+
+def validate_region_run_args(args: argparse.Namespace, skip_base: bool = False):
+    """
+    Validates the arguments processed at the level of the intermediary Region class.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        skip_base (bool): Skip validating the base class argument values. This eliminates redundant checks when
+            validating the arguments of the parent classes in this multiple inheritance class system.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    if not skip_base:
+        validate_run_args(args)
+    
+    try:
+        if not(args.identity <= 100 and args.identity >= 0):
+            raise ValueError("Identity threshold should be between 0 and 100 in case of region-based dereplication.")
+        if not(args.margin >= 0):
+            raise ValueError("Region margin cannot be negative when dereplicating regions.")
+    except ValueError as err:
+        LOG.error(f'{err}')
+        raise err
+        
+    return None
+
+
+def validate_local_genome_run_args(args: argparse.Namespace) -> None:
+    """
+    Validates the arguments for a local genome-based dereplication run.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    validate_local_run_args(args)
+    validate_genome_run_args(args, skip_base = True)
+    
+    return None
+
+
+def validate_local_region_run_args(args: argparse.Namespace) -> None:
+    """
+    Validates the arguments for a local region-based dereplication run.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    validate_local_run_args(args)
+    validate_region_run_args(args, skip_base = True)
+    
+    return None
+
+
+def validate_remote_genome_run_args(args: argparse.Namespace) -> None:
+    """
+    Validates the arguments for a remote genome-based dereplication run.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    validate_remote_run_args(args)
+    validate_genome_run_args(args, skip_base = True)
+    
+    if not(args.download_batch > 0): 
+        raise ValueError("Download batch should be larger than 0.")
+        
+    return None
+
+
+def validate_remote_region_run_args(args: argparse.Namespace) -> None:
+    """
+    Validates the arguments for a remote region-based dereplication run.
+    
+    Args:
+        args (argparse.Namespace): Namespace object holding the arguments parsed through the CLI.
+        
+    Returns:
+        None
+        
+    Raises:
+        ValueError: If an invalid argument value was passed
+    """
+    
+    validate_remote_run_args(args)
+    validate_region_run_args(args, skip_base = True)
+    
+    return None
+


### PR DESCRIPTION
Refactoring to harmonise integration in `csuite`.

- Handle temporary directories via shutil rather than a context
- Split off argument parsing function to validators
- Keep arguments in an unparsed Namespace before validating their values and initiating a workflow
- Reconfigure logger